### PR TITLE
Define _GNU_SOURCE for pthread_setname_np()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # GNU General Public License for more details.
 
 CC	= gcc
-CFLAGS	= -Wall $(EXTRA_CFLAGS) -pthread
+CFLAGS	= -Wall -D_GNU_SOURCE $(EXTRA_CFLAGS) -pthread
 LDLIBS	= -lm -lrt -pthread $(EXTRA_LDFLAGS)
 
 OBJS	= esmc_socket.o synce_clock.o synce_dev.o synce_dev_ctrl.o \


### PR DESCRIPTION
This fixes the following compiler warning:

````
synce_port_ctrl.c: In function ‘synce_port_ctrl_thread_create’: synce_port_ctrl.c:732:15: warning: implicit declaration of function ‘pthread_setname_np’; did you mean ‘pthread_setcanceltype’? [-Wimplicit-function-declaration]
  732 |         err = pthread_setname_np(*thread_id, thread_name);
````