### PR TITLE
Fix -Wformat-truncation warnings

### DIFF
--- a/config.c
+++ b/config.c
@@ -186,7 +186,8 @@ static struct config_item *config_section_item(struct config *cfg,
 {
 	char buf[CONFIG_LABEL_SIZE + MAX_IFNAME_SIZE];
 
-	snprintf(buf, sizeof(buf), "%s.%s", section, name);
+	if (snprintf(buf, sizeof(buf), "%s.%s", section, name) >= sizeof(buf))
+		return NULL;
 	return hash_lookup(cfg->htab, buf);
 }
 
@@ -629,7 +630,11 @@ struct config *config_create()
 	for (i = 0; i < end; i++) {
 		ci = &ci_tab[i];
 		ci->flags |= CFG_ITEM_STATIC;
-		snprintf(buf, sizeof(buf), "global.%s", ci->label);
+		if (snprintf(buf, sizeof(buf), "global.%s", ci->label) >=
+		    sizeof(buf)) {
+			fprintf(stderr, "option %s too long\n", ci->label);
+			goto fail;
+		}
 		if (hash_insert(cfg->htab, buf, ci)) {
 			fprintf(stderr, "duplicate item %s\n", ci->label);
 			goto fail;


### PR DESCRIPTION
This should fix the following warnings from gcc (same patch was submitted to linuxptp):

````
config.c: In function ‘config_create’:
config.c:632:52: warning: ‘%s’ directive output may be truncated writing up to 1839 bytes into a region of size 33 [-Wformat-truncation=]
  632 |                 snprintf(buf, sizeof(buf), "global.%s", ci->label);
      |                                                    ^~
config.c:632:17: note: ‘snprintf’ output between 8 and 1847 bytes into a destination of size 40
  632 |                 snprintf(buf, sizeof(buf), "global.%s", ci->label);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
config.c:189:40: warning: ‘%s’ directive output may be truncated writing up to 1839 bytes into a region of size 133  -Wformat-truncation=]
  189 |         snprintf(buf, sizeof(buf), "%s.%s", section, name);
      |                                        ^~
In function ‘config_section_item’,
    inlined from ‘config_global_item’ at config.c:196:9,
    inlined from ‘config_create’ at config.c:642:8:
config.c:189:9: note: ‘snprintf’ output between 8 and 1847 bytes into a destination of size 140
  189 |         snprintf(buf, sizeof(buf), "%s.%s", section, name);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````

Signed-off-by: Miroslav Lichvar <mlichvar@redhat.com>