### PR TITLE
Don't link with libm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 CC	= gcc
 CFLAGS	= -Wall -D_GNU_SOURCE $(EXTRA_CFLAGS) -pthread
-LDLIBS	= -lm -lrt -pthread $(EXTRA_LDFLAGS)
+LDLIBS	= -lrt -pthread $(EXTRA_LDFLAGS)
 
 OBJS	= esmc_socket.o synce_clock.o synce_dev.o synce_dev_ctrl.o \
  synce_msg.o synce_port.o synce_port_ctrl.o synce_transport.o \


### PR DESCRIPTION
There are no math functions currently used. Remove -lm from the linker flags.