### PR TITLE
Avoid -Wmaybe-uninitialized warning

### DIFF
--- a/config.c
+++ b/config.c
@@ -283,7 +283,7 @@ static enum parser_result parse_item(struct config *cfg,
 	enum parser_result r;
 	struct config_item *cgi, *dst;
 	struct config_enum *cte;
-	double df;
+	double df = 0.0;
 	int val;
 
 	r = parse_fault_interval(cfg, section, option, value);


### PR DESCRIPTION
This avoids the following false positive from gcc:

````
config.c:352:28: error: 'df' may be used uninitialized [-Werror=maybe-uninitialized]
  352 |                 dst->val.d = df;
      |                            ^
config.c: In function 'config_read':
config.c:286:16: note: 'df' was declared here
  286 |         double df;
      |                ^
````