### PR TITLE
Add external API for managing QL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CFLAGS	= -Wall -Wextra -Werror $(EXTRA_CFLAGS) -pthread -DVERSION=$(VERSION) \
 LDLIBS	= -lm -lrt -pthread -lnl-genl-3 -lnl-3 $(EXTRA_LDFLAGS)
 OBJS	= esmc_socket.o dpll_mon.o nl_dpll.o synce_clock.o synce_dev.o \
 	  synce_dev_ctrl.o  synce_msg.o synce_port.o synce_port_ctrl.o \
-	  synce_transport.o  synce_ext_src.o synce_clock_source.o config.o \
+	  synce_manager.o synce_transport.o  synce_ext_src.o synce_clock_source.o config.o \
 	  hash.o interface.o print.o util.o
 HEADERS = $(OBJS:.o=.h)
 BINARY 	= synce4l

--- a/config.c
+++ b/config.c
@@ -173,6 +173,7 @@ struct config_item {
 struct config_item config_tab_synce[] = {
 	GLOB_ITEM_INT("logging_level", LOG_INFO, PRINT_LEVEL_MIN, PRINT_LEVEL_MAX),
 	GLOB_ITEM_STR("message_tag", NULL),
+	GLOB_ITEM_STR("smc_socket_path", "/tmp/synce4l_socket"),
 	GLOB_ITEM_INT("use_syslog", 1, 0, 1),
 	GLOB_ITEM_STR("userDescription", ""),
 	GLOB_ITEM_INT("verbose", 0, 0, 1),

--- a/configs/synce4l.cfg
+++ b/configs/synce4l.cfg
@@ -7,6 +7,7 @@ logging_level		7
 use_syslog		0
 verbose			1
 message_tag		[synce4l]
+smc_socket_path		/tmp/synce4l_socket
 
 
 #

--- a/configs/synce4l_dpll.cfg
+++ b/configs/synce4l_dpll.cfg
@@ -7,6 +7,7 @@ logging_level		6
 use_syslog		0
 verbose			1
 message_tag		[synce4l]
+smc_socket_path		/tmp/synce4l_socket
 
 
 #

--- a/synce_clock.h
+++ b/synce_clock.h
@@ -7,10 +7,12 @@
 #ifndef HAVE_SYNCE_CLOCK_H
 #define HAVE_SYNCE_CLOCK_H
 
+#include <stdint.h>
 #include "config.h"
 
 /* Opaque type */
 struct synce_clock;
+struct synce_dev;
 
 /**
  * Create a SyncE clock instance.
@@ -36,4 +38,22 @@ void synce_clock_destroy(struct synce_clock *clk);
  */
 int synce_clock_poll(struct synce_clock *clk);
 
+/**
+ * return device instance from clock.
+ *
+ * @param clk		Questioned instance
+ * @param dev_name	dev_name to search
+ * @param dev		on return, return pointer to dev instance
+ * @return		0 if found or -1 if not found
+ */
+int synce_clock_get_dev(struct synce_clock *clk, char *dev_name,
+			struct synce_dev **dev);
+
+/**
+ * return socket path of clock.
+ *
+ * @param clk		Questioned instance
+ * @return		socket_path name
+ */
+char *synce_clock_get_socket_path(struct synce_clock *clk);
 #endif

--- a/synce_dev.h
+++ b/synce_dev.h
@@ -63,4 +63,49 @@ void synce_dev_destroy(struct synce_dev *dev);
  */
 int synce_dev_is_running(struct synce_dev *dev);
 
+/**
+ * Return QL of the device.
+ *
+ * @param dev		Questioned SyncE device
+ * @param ql		on return, return the current QL of device
+ */
+void synce_dev_get_ql(struct synce_dev *dev, uint8_t *ql);
+
+/**
+ * Return EXT_QL of the device.
+ *
+ * @param dev		Questioned SyncE device
+ * @param ext_ql	on return, return the current EXT_QL of device
+ */
+void synce_dev_get_ext_ql(struct synce_dev *dev, uint8_t *ext_ql);
+
+/**
+ * checks if external clock source exists.
+ *
+ * @param dev		related device
+ * @param ext_src_name	on success, returns the name of external clock source
+ *			specified in command
+ *
+ * @return		0 on success or -1 on bad command
+ */
+int synce_dev_check_ext_src_name(struct synce_dev *dev, char *ext_src_name);
+
+/**
+ * Set QL or EXT_QL of external clock source of device.
+ *
+ * @param dev		SyncE device to configure
+ * @param ext_src_name	Name of the external clock source to configure
+ * @param extended	if extended = 0 set QL, otherwise set EXT_QL
+ * @param ql		new QL/EXT_QL value
+ */
+void synce_dev_set_ext_src_ql(struct synce_dev *dev, char *ext_src_name,
+			      int extended, int ql);
+
+/**
+ * Get name of a device.
+ *
+ * @param device	Questioned instance
+ * @return		Name of a device
+ */
+const char *synce_dev_get_name(struct synce_dev *dev);
 #endif

--- a/synce_external_api.h
+++ b/synce_external_api.h
@@ -1,0 +1,30 @@
+/**
+ * @file synce_external_api.h
+ * @brief external API definition for synce4l
+ * @note SPDX-FileCopyrightText: Copyright 2023 Intel Corporation
+ * @note SPDX-License-Identifier: GPL-2.0+
+ */
+#ifndef HAVE_SYNCE_EXTERNL_API_H
+#define HAVE_SYNCE_EXTERNL_API_H
+
+#define MAX_COMMAND_SIZE		256
+#define MAX_RESPONSE_SIZE		256
+
+enum synce_manager_type {
+	MSG_DEV_NAME = 1,
+	MSG_SRC_NAME,
+	MSG_ERR_MSG,
+	MSG_GET_QL,
+	MSG_GET_EXT_QL,
+	MSG_SET_QL,
+	MSG_SET_EXT_QL,
+	MSG_END_MARKER,
+};
+
+struct synce_manager_tlv {
+	uint16_t type;	// enum synce_manager_type
+	uint16_t length;// length in bytes
+	void *value;	// data of given length
+};
+
+#endif

--- a/synce_manager.c
+++ b/synce_manager.c
@@ -1,0 +1,396 @@
+/**
+ * @file synce_manager.c
+ * @brief Interface for managing QL for external clock sources
+ * @note SPDX-FileCopyrightText: Copyright 2023 Intel Corporation
+ * @note SPDX-License-Identifier: GPL-2.0+
+ */
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <net/if.h>
+#include <ctype.h>
+#include <errno.h>
+#include "print.h"
+#include "config.h"
+#include "synce_dev.h"
+#include "synce_clock.h"
+#include "synce_manager.h"
+#include "synce_thread_common.h"
+#include "synce_external_api.h"
+
+struct synce_clock;
+
+void synce_manager_generate_err_tlv(struct synce_manager_tlv **err_tlv,
+				    char *err_str)
+{
+	*err_tlv = malloc(sizeof(struct synce_manager_tlv));
+	if (!*err_tlv) {
+		pr_err("Failed allocating error synce_manager_tlv");
+		return;
+	}
+
+	(*err_tlv)->type = MSG_ERR_MSG;
+	(*err_tlv)->length = strlen(err_str);
+	(*err_tlv)->value = malloc((*err_tlv)->length);
+	if (!(*err_tlv)->value) {
+		pr_err("Failed allocating error synce_manager_tlv msg");
+		return;
+	}
+	memcpy((*err_tlv)->value, err_str, (*err_tlv)->length);
+}
+
+int synce_manager_parse_input(const uint8_t *input,
+			      struct synce_manager_tlv **tlv_array,
+			      int *tlv_num, char *dev_name,
+			      char *ext_src_name,
+			      struct synce_manager_tlv **err_tlv)
+{
+	char err_response[MAX_ERR_RESPONSE_STR_SIZE];
+	struct synce_manager_tlv new_tlv;
+	int index = 0;
+
+	*tlv_num = 0;
+	*tlv_array = NULL;
+
+	while (index < MAX_COMMAND_SIZE) {
+		memset(&new_tlv, 0, sizeof(struct synce_manager_tlv));
+
+		if (index + 2 * sizeof(uint16_t) > MAX_COMMAND_SIZE) {
+			sprintf(err_response, "Command size exceeds %d",
+				MAX_COMMAND_SIZE);
+			synce_manager_generate_err_tlv(err_tlv, err_response);
+			return -1;
+		}
+		new_tlv.type = *(uint16_t *)(input + index);
+		index += sizeof(uint16_t);
+
+		if (new_tlv.type == MSG_END_MARKER)
+			return 0;
+
+		new_tlv.length = *(uint16_t *)(input + index);
+		index += sizeof(uint16_t);
+		if (new_tlv.length + index > MAX_COMMAND_SIZE) {
+			sprintf(err_response, "Command size exceeds %d",
+				MAX_COMMAND_SIZE);
+			synce_manager_generate_err_tlv(err_tlv, err_response);
+			return -1;
+		}
+
+		if (new_tlv.length > 0) {
+			new_tlv.value = malloc(new_tlv.length);
+			if (!new_tlv.value) {
+				synce_manager_generate_err_tlv(err_tlv, "Internal parsing error");
+				pr_err("%s Failed allocating memory", __func__);
+				return -1;
+			}
+
+			memcpy(new_tlv.value, input + index, new_tlv.length);
+			index += new_tlv.length;
+		} else {
+			new_tlv.value = NULL;
+		}
+
+		*tlv_array = realloc(*tlv_array, (*tlv_num + 1) *
+				     sizeof(struct synce_manager_tlv));
+		if (!*tlv_array) {
+			synce_manager_generate_err_tlv(err_tlv, "Internal parsing error");
+			pr_err("%s Failed reallocating memory", __func__);
+			return -1;
+		}
+
+		(*tlv_array)[*tlv_num] = new_tlv;
+		(*tlv_num)++;
+		if (new_tlv.type == MSG_DEV_NAME) {
+			if (new_tlv.length < IF_NAMESIZE) {
+				memcpy(dev_name, new_tlv.value, new_tlv.length);
+				dev_name[new_tlv.length] = '\0';
+			} else {
+				sprintf(err_response, "Dev name size exceeds %d",
+					IF_NAMESIZE);
+				synce_manager_generate_err_tlv(err_tlv,
+							       err_response);
+				return -1;
+			}
+		} else if (new_tlv.type == MSG_SRC_NAME) {
+			if (new_tlv.length < IF_NAMESIZE) {
+				memcpy(ext_src_name, new_tlv.value,
+				       new_tlv.length);
+				ext_src_name[new_tlv.length] = '\0';
+			} else {
+				sprintf(err_response, "External source name size exceeds %d",
+					IF_NAMESIZE);
+				synce_manager_generate_err_tlv(err_tlv,
+							       err_response);
+				return -1;
+			}
+		}
+	}
+
+	synce_manager_generate_err_tlv(err_tlv, "END_MARKER missing from command");
+	return -1;
+}
+
+void synce_manager_execute_tlv_array(struct synce_manager_tlv *tlv_array,
+				     int tlv_num, struct synce_dev *dev,
+				     char *ext_src_name,
+				     struct synce_manager_tlv **err_tlv)
+{
+	uint8_t val;
+	int i;
+
+	for (i = 0; i < tlv_num; i++) {
+		switch (tlv_array[i].type) {
+		case MSG_DEV_NAME:
+		case MSG_SRC_NAME:
+			break;
+		case MSG_GET_QL:
+			synce_dev_get_ql(dev, &val);
+			tlv_array[i].length = sizeof(uint8_t);
+			tlv_array[i].value = malloc(sizeof(uint8_t));
+			if (!tlv_array[i].value) {
+				synce_manager_generate_err_tlv(err_tlv, "Internal parsing error");
+				pr_err("%s Failed allocating memory", __func__);
+				return;
+			}
+			memcpy(tlv_array[i].value, &val, sizeof(uint8_t));
+			break;
+		case MSG_GET_EXT_QL:
+			synce_dev_get_ext_ql(dev, &val);
+			tlv_array[i].length = sizeof(uint8_t);
+			tlv_array[i].value = malloc(sizeof(uint8_t));
+			if (!tlv_array[i].value) {
+				synce_manager_generate_err_tlv(err_tlv, "Internal parsing error");
+				pr_err("%s Failed allocating memory", __func__);
+				return;
+			}
+			memcpy(tlv_array[i].value, &val, sizeof(uint8_t));
+			break;
+		case MSG_SET_QL:
+			if (!*ext_src_name) {
+				synce_manager_generate_err_tlv(err_tlv, "missing ext_src name");
+				return;
+			}
+			if (tlv_array[i].length > sizeof(uint8_t)) {
+				synce_manager_generate_err_tlv(err_tlv, "Bad QL value");
+				return;
+			}
+			memcpy(&val, tlv_array[i].value, sizeof(uint8_t));
+			synce_dev_set_ext_src_ql(dev, ext_src_name, 0, val);
+			break;
+		case MSG_SET_EXT_QL:
+			if (!*ext_src_name) {
+				synce_manager_generate_err_tlv(err_tlv, "missing ext_src name");
+				return;
+			}
+			if (tlv_array[i].length > sizeof(uint8_t)) {
+				synce_manager_generate_err_tlv(err_tlv, "Bad QL value");
+				return;
+			}
+			memcpy(&val, tlv_array[i].value, sizeof(uint8_t));
+			synce_dev_set_ext_src_ql(dev, ext_src_name, 1, val);
+			break;
+		default:
+			synce_manager_generate_err_tlv(err_tlv, "Bad command");
+			return;
+		}
+	}
+}
+
+int synce_manager_generate_response(struct synce_manager_tlv *resp_tlv,
+				    int tlv_num, uint8_t *response,
+				    int *resp_len)
+{
+	int i;
+
+	*resp_len = 0;
+	for (i = 0; i < tlv_num; i++) {
+		if (*resp_len + 2 * sizeof(uint16_t) + resp_tlv[i].length >
+		    MAX_RESPONSE_SIZE_WO_MARKER) {
+			pr_err("response message too big");
+			return -1;
+		}
+
+		if (!resp_tlv[i].value) {
+			pr_err("bad TLV for response");
+			return -1;
+		}
+
+		*(uint16_t *)(response + *resp_len) = resp_tlv[i].type;
+		*resp_len += sizeof(uint16_t);
+
+		*(uint16_t *)(response + *resp_len) = resp_tlv[i].length;
+		*resp_len += sizeof(uint16_t);
+
+		memcpy(response + *resp_len, resp_tlv[i].value,
+		       resp_tlv[i].length);
+		*resp_len += resp_tlv[i].length;
+	}
+	*(uint16_t *)(response + *resp_len) = MSG_END_MARKER;
+	*resp_len += sizeof(uint16_t);
+	*(uint16_t *)(response + *resp_len) = 0;
+	*resp_len += sizeof(uint16_t);
+
+	return 0;
+}
+
+void *synce_manager_server_thread(void *arg)
+{
+	struct synce_clock *clk = (struct synce_clock *)arg;
+	int tlv_num, ret, i, resp_len, bytes_read;
+	uint8_t response[MAX_RESPONSE_SIZE];
+	struct synce_manager_tlv *tlv_array;
+	struct synce_manager_tlv *err_tlv;
+	struct sockaddr_un server, client;
+	uint8_t command[MAX_COMMAND_SIZE];
+	char ext_src_name[IF_NAMESIZE];
+	int addrlen = sizeof(server);
+	char dev_name[IF_NAMESIZE];
+	int server_fd, new_socket;
+	struct synce_dev *dev;
+
+	server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (server_fd == 0) {
+		pr_err("%s Socket creation failed", __func__);
+		exit(EXIT_FAILURE);
+	}
+
+	server.sun_family = AF_UNIX;
+	strncpy(server.sun_path, synce_clock_get_socket_path(clk),
+		sizeof(server.sun_path));
+
+	if (bind(server_fd, (struct sockaddr *)&server, sizeof(server)) < 0) {
+		pr_err("%s Bind failed", __func__);
+		exit(EXIT_FAILURE);
+	}
+
+	if (listen(server_fd, 3) < 0) {
+		pr_err("%s Listen failed", __func__);
+		exit(EXIT_FAILURE);
+	}
+
+	while (1) {
+		memset(ext_src_name, 0, sizeof(ext_src_name));
+		memset(dev_name, 0, sizeof(dev_name));
+		memset(response, 0, sizeof(response));
+		memset(command, 0, sizeof(command));
+		tlv_array = NULL;
+		err_tlv = NULL;
+
+		new_socket = accept(server_fd, (struct sockaddr *)&client,
+				    (socklen_t *)&addrlen);
+		if (new_socket < 0) {
+			pr_err("%s Accept failed", __func__);
+			exit(EXIT_FAILURE);
+		}
+
+		// Read the client's command
+		bytes_read = recv(new_socket, command, MAX_COMMAND_SIZE, 0);
+		if (bytes_read < 0) {
+			synce_manager_generate_err_tlv(&err_tlv, "NULL command");
+			goto return_response;
+		}
+		ret = synce_manager_parse_input(command, &tlv_array, &tlv_num,
+						dev_name, ext_src_name,
+						&err_tlv);
+		if (ret)
+			goto return_response;
+
+		ret = synce_clock_get_dev(clk, dev_name, &dev);
+		if (ret) {
+			synce_manager_generate_err_tlv(&err_tlv, "Device not found");
+			goto return_response;
+		}
+
+		if (*ext_src_name) {
+			ret = synce_dev_check_ext_src_name(dev, ext_src_name);
+			if (ret) {
+				synce_manager_generate_err_tlv(&err_tlv, "External clock source not found");
+				goto return_response;
+			}
+		}
+
+		synce_manager_execute_tlv_array(tlv_array, tlv_num, dev,
+						ext_src_name, &err_tlv);
+
+return_response:
+		if (err_tlv) {
+			ret = synce_manager_generate_response(err_tlv, 1,
+							      response,
+							      &resp_len);
+			if (err_tlv->value)
+				free(err_tlv->value);
+			free((void *)err_tlv);
+		} else {
+			ret = synce_manager_generate_response(tlv_array,
+							      tlv_num,
+							      response,
+							      &resp_len);
+		}
+
+		for (i = 0; i < tlv_num; i++) {
+			if (tlv_array[i].value)
+				free(tlv_array[i].value);
+		}
+		if (tlv_array)
+			free((void *)tlv_array);
+
+		if (!ret)
+			write(new_socket, response, resp_len);
+		close(new_socket);
+	}
+
+	return NULL;
+}
+
+int synce_manager_start_thread(struct synce_clock *clk)
+{
+	char thread_name[TASK_COMM_LEN];
+	pthread_t server_tid;
+	pthread_attr_t attr;
+	int err;
+
+	err = pthread_attr_init(&attr);
+	if (err) {
+		pr_err("init thread attr failed for synce_manager");
+		goto err_attr;
+	}
+
+	err = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+	if (err) {
+		pr_err("set thread detached failed for synce_manager err=%d",
+		       err);
+		goto err_attr;
+	}
+
+	err = pthread_attr_setstacksize(&attr, SYNCE_THREAD_STACK_SIZE);
+	if (err) {
+		pr_err("set thread stack failed for synce_manager err=%d",
+		       err);
+		goto err_attr;
+	}
+
+	err = pthread_create(&server_tid, &attr, synce_manager_server_thread,
+			     (void *)clk);
+	if (err) {
+		pr_err("create thread failed for synce_manager err=%d", err);
+		goto err_attr;
+	}
+
+	snprintf(thread_name, TASK_COMM_LEN, "synce-manager");
+	err = pthread_setname_np(server_tid, thread_name);
+	if (err)
+		pr_info("failed to set thread's name for synce_manager");
+
+	pthread_attr_destroy(&attr);
+	return 0;
+
+err_attr:
+	pthread_attr_destroy(&attr);
+	return -ECHILD;
+}
+
+void synce_manager_close_socket(char *socket_path)
+{
+	unlink(socket_path);
+}

--- a/synce_manager.h
+++ b/synce_manager.h
@@ -1,0 +1,28 @@
+/**
+ * @file synce_manager.h
+ * @brief Interface for managing synce4l while running
+ * @note SPDX-FileCopyrightText: Copyright 2023 Intel Corporation
+ * @note SPDX-License-Identifier: GPL-2.0+
+ */
+#ifndef HAVE_SYNCE_MANAGER_H
+#define HAVE_SYNCE_MANAGER_H
+
+#define MAX_RESPONSE_SIZE_WO_MARKER	(MAX_RESPONSE_SIZE - 2 * sizeof(uint16_t))
+#define MAX_ERR_RESPONSE_STR_SIZE	(MAX_RESPONSE_SIZE_WO_MARKER - 2 * sizeof(uint16_t))
+
+/**
+ * Starts synce_manager thread for handling external commands.
+ *
+ * @param clk		synce_clock instance
+ * @return		0 on success or -1 on bad command
+ */
+int synce_manager_start_thread(struct synce_clock *clk);
+
+/**
+ * Removes local socket file.
+ *
+ * @param socket_path		socket_path name
+ */
+void synce_manager_close_socket(char *socket_path);
+
+#endif


### PR DESCRIPTION
Add user space API to fetch current card QL and dynamically set QL of clock source received on SMA port to enable 3rd-party application to synchronize QL between nodes using scenario-specific methods

3rd-party application can use the following commands:
	SET <dev_name> <sma_name> <QL/EXT_QL> <ql_value> Sets the QL or EXT QL
							 of sma of a device with
							 ql_value
	GET <dev_name>					 Gets the current QL and
							 ext QL of a device