### PR TITLE
Avoid false -Wmaybe-uninitialized warning

### DIFF
--- a/dpll_mon.c
+++ b/dpll_mon.c
@@ -331,7 +331,7 @@ static void update_muxed_pin(struct dpll_mon *dm, uint32_t pin_id,
 			     struct nlattr *a, int exist, int notify)
 {
 	int parent_pin_id_valid = 0, pin_state_valid = 0, rem;
-	uint32_t parent_pin_id, pin_state;
+	uint32_t parent_pin_id = 0, pin_state = 0;
 	struct dpll_mon_pin *pin, *parent;
 	struct nlattr *an;
 


### PR DESCRIPTION
This fixes false positives reported by an older gcc:

````    
    In file included from dpll_mon.c:17:
    dpll_mon.c: In function 'dpll_mon_pin_update':
    print.h:54:17: error: 'pin_state' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       54 |                 print(l, x);                            \
          |                 ^~~~~
    dpll_mon.c:334:33: note: 'pin_state' was declared here
      334 |         uint32_t parent_pin_id, pin_state;
          |                                 ^~~~~~~~~
    print.h:54:17: error: 'parent_pin_id' may be used uninitialized in this
    function [-Werror=maybe-uninitialized]
       54 |                 print(l, x);                            \
          |                 ^~~~~
    dpll_mon.c:334:18: note: 'parent_pin_id' was declared here
      334 |         uint32_t parent_pin_id, pin_state;
          |                  ^~~~~~~~~~~~~

````