### PR TITLE
Printf() type fix

### DIFF
--- a/config.c
+++ b/config.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <net/if.h>
 
 #include "config.h"
@@ -767,7 +768,7 @@ config_get_u64(struct config *cfg, const char *section, const char *option)
 		pr_err("bug: config option %s type mismatch!", option);
 		exit(-1);
 	}
-	pr_debug("config item %s.%s is %lu (0x%lx)", section, option,
+	pr_debug("config item %s.%s is %" PRIu64 " (0x%" PRIx64 ")", section, option,
 		 ci->val.u64, ci->val.u64);
 	return ci->val.u64;
 }

--- a/nl_dpll.c
+++ b/nl_dpll.c
@@ -9,6 +9,7 @@
 #include <netlink/genl/ctrl.h>
 #include <linux/rtnetlink.h>
 #include <errno.h>
+#include <inttypes.h>
 #include "nl_dpll.h"
 #include "print.h"
 

--- a/nl_dpll.c
+++ b/nl_dpll.c
@@ -118,7 +118,7 @@ int nl_dpll_device_id_get(struct nl_sock *sk, struct sk_arg *arg,
 		pr_err("%s: failed to send request", __func__);
 		goto msg_free;
 	}
-	pr_debug("DEVICE_ID_GET request sent dpll id: %lu %s, ret:%d",
+	pr_debug("DEVICE_ID_GET request sent dpll id: %" PRIu64 " %s, ret:%d",
 		 clock_id, module_name, ret);
 
 	arg->err = 0;


### PR DESCRIPTION
Unable to build 1.0.0 on RPi OS (64 bit) due to mismatch with printf() types for 64 bit ints. This patch correct that issue by using generic types from inttypes.h.