### PR TITLE
Update port TX QL when external source locks

### DIFF
--- a/synce_dev.c
+++ b/synce_dev.c
@@ -660,6 +660,10 @@ static int dev_step_dpll(struct synce_dev *dev)
 		dev->best_source = active;
 		pr_info("EEC_LOCKED/EEC_LOCKED_HO_ACQ on %s of %s",
 			dev->best_source->ext_src->name, dev->name);
+		LIST_FOREACH(c, &dev->clock_sources, list) {
+			if (c->type == PORT)
+				set_port_ql_from_ext_src(dev, c->port, active->ext_src);
+		}
 		dev_update_ql(dev);
 	} else if (active->type == PORT) {
 		dev->ext_src_is_best = 0;


### PR DESCRIPTION
This is an attempt to fix the issue with incorrect transmitted QL when multiple external sources are configured, but not the best one is selected and locks. The issue is that the forced QL is not updated to according to the source.

This works in my tests, but I'm not sure if it's the best approach. Maybe `find_dev_best_clock_source()` should be called at some point instead.