### PR TITLE
Fix infinite loop in selection between two SyncE clocks

### DIFF
--- a/dpll_mon.c
+++ b/dpll_mon.c
@@ -972,7 +972,7 @@ int set_prio(struct dpll_mon *dm, uint32_t pin_id, uint32_t prio)
 				    dm->dpll_id, prio);
 }
 
-static int dpll_mon_pin_prio_clear(struct dpll_mon *dm, struct dpll_mon_pin *pin)
+int dpll_mon_pin_prio_clear(struct dpll_mon *dm, struct dpll_mon_pin *pin)
 {
 	struct dpll_mon_pin *parent;
 	struct parent_pin *pp;

--- a/dpll_mon.h
+++ b/dpll_mon.h
@@ -120,6 +120,15 @@ int dpll_mon_pin_prio_set(struct dpll_mon *dm, struct dpll_mon_pin *pin,
 			  uint32_t prio);
 
 /**
+ * Request to reset the priority of a pin to dnu_prio.
+ *
+ * @param dm		Instance of dpll mon which owns the pin.
+ * @param pin		Valid pointer to a pin.
+ * @return		0 - success, negative - failed to send request
+ */
+int dpll_mon_pin_prio_clear(struct dpll_mon *dm, struct dpll_mon_pin *pin);
+
+/**
  * Request to set Do Not Use priority on all valid pins for all the pins
  * controlled by the dpll_mon's dpll.
  *

--- a/synce_clock_source.c
+++ b/synce_clock_source.c
@@ -220,3 +220,18 @@ int synce_clock_source_prio_set(struct dpll_mon *dpll_mon,
 					   prio);
 	return synce_ext_src_prio_set(dpll_mon, clk_src->ext_src, prio);
 }
+
+int synce_clock_source_prio_clear(struct dpll_mon *dpll_mon,
+				  struct synce_clock_source *clk_src)
+{
+	if (!clk_src) {
+		pr_err("%s clock_source is NULL", __func__);
+		return -ENODEV;
+	}
+	pr_debug("%s: clear prio on %s", __func__,
+		 clk_src->type == PORT ? clk_src->port->name :
+		 clk_src->ext_src->name);
+	if (clk_src->type == PORT)
+		return synce_port_prio_clear(dpll_mon, clk_src->port);
+	return synce_ext_src_prio_clear(dpll_mon, clk_src->ext_src);
+}

--- a/synce_clock_source.h
+++ b/synce_clock_source.h
@@ -132,4 +132,14 @@ int synce_clock_source_prio_set(struct dpll_mon *dpll_mon,
 				struct synce_clock_source *clk_src,
 				uint32_t prio);
 
+/**
+ * request to set priority of a clock source pin on a dpll to dnu_prio
+ *
+ * @param dpll_mon	Pointer to dpll_mon class
+ * @param clk_src	Configured instance
+ * @return		0 - success, error code - failure
+ */
+int synce_clock_source_prio_clear(struct dpll_mon *dpll_mon,
+				  struct synce_clock_source *clk_src);
+
 #endif /* HAVE_SYNCE_CLOCK_SOURCE_H */

--- a/synce_ext_src.c
+++ b/synce_ext_src.c
@@ -204,3 +204,9 @@ int synce_ext_src_prio_set(struct dpll_mon *dpll_mon,
 {
 	return dpll_mon_pin_prio_set(dpll_mon, ext_src->pin, prio);
 }
+
+int synce_ext_src_prio_clear(struct dpll_mon *dpll_mon,
+			     struct synce_ext_src *ext_src)
+{
+	return dpll_mon_pin_prio_clear(dpll_mon, ext_src->pin);
+}

--- a/synce_ext_src.h
+++ b/synce_ext_src.h
@@ -128,4 +128,14 @@ int synce_ext_src_is_active(struct dpll_mon *dpll_mon,
 int synce_ext_src_prio_set(struct dpll_mon *dpll_mon,
 			   struct synce_ext_src *ext_src, uint32_t prio);
 
+/**
+ * request to set priority of a external source associated pin to dnu_prio
+ *
+ * @param dpll_mon	Pointer to dpll_mon class
+ * @param ext_src	Configured instance
+ * @return		0 - success, error code - failure
+ */
+int synce_ext_src_prio_clear(struct dpll_mon *dpll_mon,
+			     struct synce_ext_src *ext_src);
+
 #endif /* HAVE_SYNCE_EXT_SRC_H */

--- a/synce_port.c
+++ b/synce_port.c
@@ -473,3 +473,8 @@ int synce_port_prio_set(struct dpll_mon *dpll_mon, struct synce_port *port,
 {
 	return dpll_mon_pin_prio_set(dpll_mon, port->pin, prio);
 }
+
+int synce_port_prio_clear(struct dpll_mon *dpll_mon, struct synce_port *port)
+{
+	return dpll_mon_pin_prio_clear(dpll_mon, port->pin);
+}

--- a/synce_port.h
+++ b/synce_port.h
@@ -192,4 +192,13 @@ int synce_port_is_active(struct dpll_mon *dpll_mon, struct synce_port *port);
 int synce_port_prio_set(struct dpll_mon *dpll_mon, struct synce_port *port,
 			uint32_t prio);
 
+/**
+ * request to set priority of a port pin on a dpll to dnu_prio
+ *
+ * @param dpll_mon	Pointer to dpll_mon class
+ * @param port		Configured instance
+ * @return		0 - success, error code - failure
+ */
+int synce_port_prio_clear(struct dpll_mon *dpll_mon, struct synce_port *port);
+
 #endif /* HAVE_SYNCE_PORT_H */


### PR DESCRIPTION
This patch set should fix a problem when two connected SyncE clocks have external inputs and they are stuck in an infinite loop where:
- clock A selects clock B as its input
- clock A changes its transmitted QL to DNU
- clock B sees the change in QL of A and rebuilds its input priority, disconnects the external input, and changes its QL to DNU
- clock A sees the change in QL of B, rebuilds its input priority and selects its external input
- clock B locks to its external input again and changes its QL
