### PR TITLE
 fix sync on missing extended tlv

### DIFF
--- a/synce_port_ctrl.c
+++ b/synce_port_ctrl.c
@@ -722,7 +722,7 @@ uint16_t get_priority_params(struct synce_port_ctrl *pc,
 
 uint16_t get_ql_priority(struct synce_port_ctrl *pc)
 {
-	if (pc->rx.cd.extended) {
+	if (pc->rx.cd.extended && pc->rx.ext_tlv_recvd) {
 		return QL_PRIORITY(pc->rx.cd.ql,
 				   pc->rx.cd.ext_ql.enhancedSsmCode);
 	} else {


### PR DESCRIPTION
If the source port does not receive the extended tlv but SyncE device is
configured for such support, the incoming QL shall be validated with
the not-extended list of valid QLs, thus the priority and validity of
the source is correctly assigned.

Previously for described case the source was not considered as valid,
which is not compliant with the SyncE specification.

fix #38

Signed-off-by: Arkadiusz Kubalewski <arkadiusz.kubalewski@intel.com>
