### PR TITLE
synce4l: add internal device priority configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ communication.
 | `recover_clock_disable_cmd` | None    | string       | Shell command which disables PHY port pointed by this Port section as a source of frequency for the SyncE EEC on this device (required only in "internal_input" mode).            |
 | `allowed_qls`               | None    | string       | List of hex values containing allowed SSM QLs separated by comma (`,`), other received ones would be discarded - if parameter is not provided, all QLs will be accepted.          |
 | `allowed_ext_qls`           | None    | string       | List of hex values containing allowed extended SSM QLs separated by comma (`,`), other received ones would be discarded - if parameter is not provided, all QLs will be accepted. |
+| `internal_prio`             | 128     | 0-255        | An internal source priority, higher priority (lower value) is used to select a source as better quality in case two sources are considered equal quality                          |
 
 > *Remark:* Please do not use backslashes in config file in 'string' fields - for example do not use it like this: `"/sys/kernel/debug/ice/0000\:5e\:00\.0/cgu_state"`
 
@@ -177,15 +178,16 @@ Any other section not starting with `{` (e.g. {SMA1}) is the external source sec
 Multiple external source sections are allowed. Each external source participates in
 best source selection algorithm for EEC
 
-| Parameter                   | Default | Valid values       | Description                                                                                                                                           |
-| --------------------------- | ------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `input_QL`                  | `0`     | `0-15`, `0x0-0xF`  | Quality Level (QL) for "external input" mode.                                                                                                         |
-| `input_ext_QL`              | `0`     | `0-255`,`0x0-0xFF` | Extended Quality Level for "external input" mode.                                                                                                     |
-| `external_enable_cmd`       | None    | string             | Shell command which enables external clock source pointed by this external source section as a source of frequency for the SyncE EEC on this device.  |
-| `external_disable_cmd`      | None    | string             | Shell command which disables external clock source pointed by this external source section as a source of frequency for the SyncE EEC on this device. |
-| `board_label`               | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                    |
-| `panel_label`               | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                    |
-| `package_label`             | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                    |
+| Parameter                   | Default | Valid values       | Description                                                                                                                                              |
+| --------------------------- | ------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `input_QL`                  | `0`     | `0-15`, `0x0-0xF`  | Quality Level (QL) for "external input" mode.                                                                                                            |
+| `input_ext_QL`              | `0`     | `0-255`,`0x0-0xFF` | Extended Quality Level for "external input" mode.                                                                                                        |
+| `external_enable_cmd`       | None    | string             | Shell command which enables external clock source pointed by this external source section as a source of frequency for the SyncE EEC on this device.     |
+| `external_disable_cmd`      | None    | string             | Shell command which disables external clock source pointed by this external source section as a source of frequency for the SyncE EEC on this device.    |
+| `board_label`               | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                       |
+| `panel_label`               | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                       |
+| `package_label`             | None    | string             | Used for Linux dpll subsystem based configuration. A label of a pin associated with the external EEC input in Linux dpll subsytem.                       |
+| `internal_prio`             | 128     | 0-255              | An internal source priority, higher priority (lower value) is used to select a source as better quality in case two sources are considered equal quality |
 
 > *Remark:* When dpll subsystem is used, a value of `board_label`, `panel_label` or `package_label` shall be provided, depending on a type of label that given input has registered in Linux dpll subsystem.
 
@@ -218,12 +220,14 @@ recover_clock_enable_cmd   echo 1 0 > /sys/class/net/eth0/device/phy/synce
 recover_clock_disable_cmd  echo 0 0 > /sys/class/net/eth0/device/phy/synce
 allowed_qls                0x2,0x4,0x8
 allowed_ext_qls            0x20,0x21
+internal_prio              1
 
 [{SMA1}]
 external_enable_cmd        echo 2 1 > /sys/class/net/enp1s0f0/device/ptp/ptp*/pins/SMA1
 external_disable_cmd       echo 0 1 > /sys/class/net/enp1s0f0/device/ptp/ptp*/pins/SMA1
 input_QL                   0x2
 input_ext_QL               0x20
+internal_prio              0
 
 ```
 
@@ -249,11 +253,13 @@ tx_heartbeat_msec          1000
 rx_heartbeat_msec          500
 allowed_qls                0x2,0x4,0x8
 allowed_ext_qls            0x20,0x21
+internal_prio              1
 
 [{SMA1}]
 board_label                SMA1
 input_QL                   0x2
 input_ext_QL               0x20
+internal_prio              0
 
 ```
 

--- a/config.c
+++ b/config.c
@@ -44,6 +44,7 @@ enum config_section {
 	PORT_SECTION,
 	DEVICE_SECTION,
 	EXT_SECTION,
+	SRC_SECTION,
 	UNKNOWN_SECTION,
 };
 
@@ -91,6 +92,7 @@ struct config_item {
 #define PORT_TO_FLAG(_port) _port == PORT_SECTION ? CFG_ITEM_PORT : \
 	_port == DEVICE_SECTION ? CFG_ITEM_DEVICE : \
 	_port == EXT_SECTION ? CFG_ITEM_EXT : \
+	_port == SRC_SECTION ? CFG_ITEM_PORT | CFG_ITEM_EXT : \
 	CFG_ITEM_STATIC
 
 #define CONFIG_ITEM_DBL(_label, _port, _default, _min, _max) {	\
@@ -170,6 +172,9 @@ struct config_item {
 #define EXT_ITEM_STR(label, _default) \
 	CONFIG_ITEM_STRING(label, EXT_SECTION, _default)
 
+#define SRC_ITEM_INT(label, _default, min, max) \
+	CONFIG_ITEM_INT(label, SRC_SECTION, _default, min, max)
+
 struct config_item config_tab_synce[] = {
 	GLOB_ITEM_INT("logging_level", LOG_INFO, PRINT_LEVEL_MIN, PRINT_LEVEL_MAX),
 	GLOB_ITEM_STR("message_tag", NULL),
@@ -205,6 +210,7 @@ struct config_item config_tab_synce[] = {
 	EXT_ITEM_INT("input_ext_QL", 0, 0, 255),
 	EXT_ITEM_STR("external_enable_cmd", NULL),
 	EXT_ITEM_STR("external_disable_cmd", NULL),
+	SRC_ITEM_INT("internal_prio", 128, 0, 255),
 };
 
 static struct interface *__config_create_interface(const char *name, struct config *cfg,

--- a/configs/synce4l.cfg
+++ b/configs/synce4l.cfg
@@ -160,6 +160,13 @@ external_enable_cmd	echo 2 1 > /sys/class/net/enp1s0f0/device/ptp/ptp*/pins/SMA1
 external_disable_cmd	echo 0 1 > /sys/class/net/enp1s0f0/device/ptp/ptp*/pins/SMA1
 
 #
+# An internal source priority, higher priority (lower value) is used to select
+# a source as better quality in case two sources are considered equal quality
+# [0-255], default:128
+#
+internal_prio	0
+
+#
 # next configured external clock source for the device
 #
 [{SMA2}]

--- a/configs/synce4l_dpll.cfg
+++ b/configs/synce4l_dpll.cfg
@@ -155,12 +155,20 @@ board_label		SMA1
 #package_label		<name>
 
 #
+# An internal source priority, higher priority (lower value) is used to select
+# a source as better quality in case two sources are considered equal quality
+# [0-255], default:128
+#
+internal_prio	0
+
+#
 # next configured external clock source for the device
 #
 [{SMA2}]
 input_QL		0x2
 input_ext_QL		0xFF
 board_label		SMA2/U.FL2
+internal_prio		1
 
 ############################################################
 #

--- a/synce_clock_source.h
+++ b/synce_clock_source.h
@@ -27,6 +27,8 @@ struct synce_clock_source {
 		struct synce_ext_src *ext_src;
 		struct synce_port *port;
 	};
+	int internal_prio;
+	const char *name;
 };
 
 /**


### PR DESCRIPTION
When building the source priority list for a device, and comparing each two clock sources it is possible that multiple sources have the same priority - the same QL (and extended QL) values.

Allow the user to explicitly assign an internal priority value for each source within config file. Use the internal priority value for final verdict when comparing two sources for their quality, previously the compare function returned "left" source as better quality even if both sources had the same priority, now the user is able to configure which source is preferred in such case.

fix #17 