### PR TITLE
Fix more compiler warnings

### DIFF
--- a/synce_dev.c
+++ b/synce_dev.c
@@ -579,7 +579,7 @@ static bool source_invalid(struct synce_clock_source *c)
 int rebuild_inputs_prio(struct synce_dev *dev)
 {
 	struct synce_clock_source *c, *best_c, **all, **prioritized;
-	int i = 0, prio_count = 0, j, best_c_idx, ret;
+	int i = 0, prio_count = 0, j, best_c_idx = 0, ret;
 	uint32_t prio;
 
 	all = calloc(dev->num_clock_sources, sizeof(*all));


### PR DESCRIPTION
Fix the following warnings observed when -O2 and -D_FORTIFY_SOURCE=2 are added to CFLAGS. (Maybe -O2 should be in the default CFLAGS?)

````
synce_dev.c: In function ‘rebuild_inputs_prio’:
synce_dev.c:610:28: warning: ‘best_c_idx’ may be used uninitialized [-Wmaybe-uninitialized]
  610 |                         all[best_c_idx] = NULL;
      |                            ^
synce_dev.c:582:39: note: ‘best_c_idx’ was declared here
  582 |         int i = 0, prio_count = 0, j, best_c_idx, ret;
      |                                       ^~~~~~~~~~

synce_manager.c: In function ‘synce_manager_server_thread’: synce_manager.c:260:9: warning: ‘strncpy’ specified bound 108 equals destination size [-Wstringop-truncation]
  260 |         strncpy(server.sun_path, synce_clock_get_socket_path(clk),
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  261 |                 sizeof(server.sun_path));
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~

synce_manager.c:343:20: warning: ‘ret’ may be used uninitialized [-Wmaybe-uninitialized]
  343 |                 if (!ret)
      |                    ^
synce_manager.c:241:26: note: ‘ret’ was declared here
  241 |         int tlv_num = 0, ret, i, resp_len, bytes_read;
      |                          ^~~

synce_manager.c: In function ‘synce_manager_server_thread’:
synce_manager.c:344:25: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  344 |                         write(new_socket, response, resp_len);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````