### PR TITLE
Improvements around smc Unix domain socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ related to a running synce4l instance.
 | `logging_level`      | `6`                   | `0-7`        | Minimum log level required to appear in a log.                  |
 | `message_tag`        | None                  | string       | Tag reported in a log.                                          |
 | `poll_interval_msec` | 20                    | 0-500        | Sleep time between subsequent SyncE clock polls                 |
-| `smc_socket_path`    | `/tmp/synce4l_socket` | string       | Full path to socket file for external application communication |
+| `smc_socket_path`    | `/run/synce4l_socket` | string       | Full path to socket file for external application communication |
 | `use_syslog`         | `1`                   | `0`, `1`     | Set to 1 if `syslog` should be used.                            |
 | `verbose`            | `0`                   | `0`, `1`     | Set to 1 to log extra information.                              |
 
@@ -200,7 +200,7 @@ logging_level              7
 use_syslog                 0
 verbose                    1
 message_tag                [synce4l]
-smc_socket_path            /tmp/synce4l_socket
+smc_socket_path            /run/synce4l_socket
 
 [<synce1>]
 network_option             1
@@ -239,7 +239,7 @@ logging_level              7
 use_syslog                 0
 verbose                    1
 message_tag                [synce4l]
-smc_socket_path            /tmp/synce4l_socket
+smc_socket_path            /run/synce4l_socket
 
 [<synce1>]
 network_option             1

--- a/config.c
+++ b/config.c
@@ -180,7 +180,7 @@ struct config_item config_tab_synce[] = {
 	GLOB_ITEM_STR("message_tag", NULL),
 	GLOB_ITEM_INT("poll_interval_msec", 20, CLOCK_POLL_INTERVAL_MIN,
 		      CLOCK_POLL_INTERVAL_MAX),
-	GLOB_ITEM_STR("smc_socket_path", "/tmp/synce4l_socket"),
+	GLOB_ITEM_STR("smc_socket_path", "/run/synce4l_socket"),
 	GLOB_ITEM_INT("use_syslog", 1, 0, 1),
 	GLOB_ITEM_STR("userDescription", ""),
 	GLOB_ITEM_INT("verbose", 0, 0, 1),

--- a/configs/synce4l.cfg
+++ b/configs/synce4l.cfg
@@ -7,7 +7,7 @@ logging_level		7
 use_syslog		0
 verbose			1
 message_tag		[synce4l]
-smc_socket_path		/tmp/synce4l_socket
+smc_socket_path		/run/synce4l_socket
 
 
 #

--- a/configs/synce4l_dpll.cfg
+++ b/configs/synce4l_dpll.cfg
@@ -7,7 +7,7 @@ logging_level		6
 use_syslog		0
 verbose			1
 message_tag		[synce4l]
-smc_socket_path		/tmp/synce4l_socket
+smc_socket_path		/run/synce4l_socket
 
 
 #

--- a/synce_manager.c
+++ b/synce_manager.c
@@ -256,6 +256,10 @@ static void *synce_manager_server_thread(void *arg)
 		exit(EXIT_FAILURE);
 	}
 
+	if (strlen(synce_clock_get_socket_path(clk)) >= sizeof(server.sun_path)) {
+		pr_err("%s smc_socket_path is too long", __func__);
+		exit(EXIT_FAILURE);
+	}
 	server.sun_family = AF_UNIX;
 	strncpy(server.sun_path, synce_clock_get_socket_path(clk),
 		sizeof(server.sun_path));

--- a/synce_manager.c
+++ b/synce_manager.c
@@ -264,6 +264,8 @@ static void *synce_manager_server_thread(void *arg)
 	strncpy(server.sun_path, synce_clock_get_socket_path(clk),
 		sizeof(server.sun_path));
 
+	unlink(server.sun_path);
+
 	if (bind(server_fd, (struct sockaddr *)&server, sizeof(server)) < 0) {
 		pr_err("%s Bind failed", __func__);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
This moves the default socket to /run to avoid a world-writable directory, adds a check to make sure the socket path is correctly terminated and unlinks the socket to allow starting when it already exists.