### PR TITLE
Initialize pin ID to -1

### DIFF
--- a/dpll_mon.c
+++ b/dpll_mon.c
@@ -240,6 +240,7 @@ static struct dpll_mon_pin *pin_create(void)
 	}
 	pr_debug("%s %p", __func__, pin);
 	pin->parent_used_by = PARENT_NOT_USED;
+	pin->id = -1;
 	STAILQ_INIT(&pin->parents);
 
 	return pin;


### PR DESCRIPTION
When creating the pin structure, initialize the pin ID to -1 to avoid matching an existing pin with ID 0 (e.g. CVL-SDP22 on E810) when a nonexistent pin is specified in the config.