### PR TITLE
Fix scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '39 18 * * 1'
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
The workflow can be used only on the default branch, remove the configuration for dev branch.