### PR TITLE
fix security scorecard build failure

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -58,12 +58,12 @@ jobs:
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
+      #      - name: "Upload artifact"
+      #        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+      #        with:
+      #          name: security-scorecard
+      #          path: results.sarif
+      #          retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intel/synce4l/badge)](https://scorecard.dev/viewer/?uri=github.com/intel/synce4l)
+
+---
+
 # Table of contents
 
 1. Introduction


### PR DESCRIPTION
Disable 'Upload artifact' step as optional and was causing issues.
Add Scorecard badge to the README.md.